### PR TITLE
RAM-26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,9 +52,9 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.23</version>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<version>9.1.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,4 +7,5 @@ spring.datasource.password=${MYSQL_PASSWORD}
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 


### PR DESCRIPTION
This pull request includes updates to the MySQL connector dependency and configuration settings in the project. The most important changes involve updating the MySQL connector version and adjusting the datasource driver class name in the application properties.

fixed #12 

Dependency updates:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L55-R57): Updated the MySQL connector dependency from version `8.0.23` to `9.1.0` and changed the group and artifact IDs to `com.mysql` and `mysql-connector-j`, respectively.

Configuration updates:

* [`src/main/resources/application.properties`](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136R10): Added the `spring.datasource.driver-class-name` property with the value `com.mysql.cj.jdbc.Driver`. 


