### PR TITLE
RAM-31

### DIFF
--- a/src/main/java/com/rickmorty/Services/CharacterService.java
+++ b/src/main/java/com/rickmorty/Services/CharacterService.java
@@ -7,6 +7,7 @@ import com.rickmorty.DTO.CharacterDto;
 import com.rickmorty.DTO.InfoDto;
 import com.rickmorty.Utils.Config;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,12 +27,13 @@ import java.util.stream.Collectors;
 @Service
 public class CharacterService {
 
-    private static final String URL_API = "https://rickandmortyapi.com/api";
+    @Autowired
+    Config config;
 
     public ApiResponseDto<CharacterDto> findAllCharacters(Integer page) {
         try {
             HttpClient client = HttpClient.newHttpClient();
-            String urlWithPage = URL_API + "/character" + (page != null ? "?page=" + page : "");
+            String urlWithPage = config.getApiBaseUrl() + "/character" + (page != null ? "?page=" + page : "");
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(urlWithPage))
                     .build();
@@ -53,7 +55,7 @@ public class CharacterService {
         try {
             HttpClient client = HttpClient.newHttpClient();
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(URL_API + "/character/" + id))
+                    .uri(URI.create(config.getApiBaseUrl() + "/character/" + id))
                     .build();
 
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
@@ -75,7 +77,7 @@ public class CharacterService {
         try {
             HttpClient client = HttpClient.newHttpClient();
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(URL_API + "/character/" + id))
+                    .uri(URI.create(config.getApiBaseUrl() + "/character/" + id))
                     .build();
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
             ObjectMapper objectMapper = new ObjectMapper();
@@ -101,13 +103,13 @@ public class CharacterService {
 
     private InfoDto rewriteInfoDto(InfoDto originalInfo) {
         String nextUrl = Optional.ofNullable(originalInfo.next())
-                .map(next -> next.replace("https://rickandmortyapi.com/api/character",
-                        Config.base_url + "/characters"))
+                .map(next -> next.replace(config.getApiBaseUrl() + "/character",
+                        config.getLocalBaseUrl() + "/characters"))
                 .orElse(null);
     
         String prevUrl = Optional.ofNullable(originalInfo.prev())
-                .map(prev -> prev.replace("https://rickandmortyapi.com/api/character",
-                        Config.base_url + "/characters"))
+                .map(prev -> prev.replace(config.getApiBaseUrl() + "/character",
+                        config.getLocalBaseUrl() + "/characters"))
                 .orElse(null);
     
         return new InfoDto(
@@ -125,11 +127,11 @@ public class CharacterService {
                 character.species(),
                 character.type(),
                 character.gender(),
-                character.image().replace("https://rickandmortyapi.com/api/character/",
-                        Config.base_url + "/characters/"),
+                character.image().replace(config.getApiBaseUrl() +"/character/",
+                        config.getLocalBaseUrl() + "/characters/"),
                 character.episode().stream()
-                        .map(episode -> episode.replace("https://rickandmortyapi.com/api/episode/",
-                                Config.base_url + "/episodes/"))
+                        .map(episode -> episode.replace(config.getApiBaseUrl() + "/episode/",
+                                config.getLocalBaseUrl() + "/episodes/"))
                         .collect(Collectors.toList()));
     }
 

--- a/src/main/java/com/rickmorty/Services/EpisodeService.java
+++ b/src/main/java/com/rickmorty/Services/EpisodeService.java
@@ -7,6 +7,8 @@ import com.rickmorty.DTO.EpisodeDto;
 import com.rickmorty.DTO.InfoDto;
 import com.rickmorty.Utils.Config;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -21,12 +23,13 @@ import java.util.stream.Collectors;
 @Service
 public class EpisodeService {
 
-    private static final String URL_API = "https://rickandmortyapi.com/api";
+    @Autowired
+    Config config;
 
     public ApiResponseDto<EpisodeDto> findAllEpisodes(Integer page) {
         try {
             HttpClient client = HttpClient.newHttpClient();
-            String urlWithPage = URL_API + "/episode" + (page != null ? "?page=" + page : "");
+            String urlWithPage = config.getApiBaseUrl() + "/episode" + (page != null ? "?page=" + page : "");
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(urlWithPage))
                     .build();
@@ -48,7 +51,7 @@ public class EpisodeService {
         try {
             HttpClient client = HttpClient.newHttpClient();
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(URL_API + "/episode/" + id))
+                    .uri(URI.create(config.getApiBaseUrl() + "/episode/" + id))
                     .build();
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
             ObjectMapper objectMapper = new ObjectMapper();
@@ -74,13 +77,13 @@ public class EpisodeService {
 
     private InfoDto rewriteInfoDto(InfoDto originalInfo) {
         String nextUrl = Optional.ofNullable(originalInfo.next())
-                .map(next -> next.replace("https://rickandmortyapi.com/api/episode",
-                        Config.base_url + "/episodes"))
+                .map(next -> next.replace(config.getApiBaseUrl()+ "/episode",
+                        config.getLocalBaseUrl() + "/episodes"))
                 .orElse(null);
     
         String prevUrl = Optional.ofNullable(originalInfo.prev())
-                .map(prev -> prev.replace("https://rickandmortyapi.com/api/episode",
-                        Config.base_url + "/episodes"))
+                .map(prev -> prev.replace(config.getApiBaseUrl() + "/episodes",
+                        config.getLocalBaseUrl() + "/episodes"))
                 .orElse(null);
     
         return new InfoDto(
@@ -97,8 +100,8 @@ public class EpisodeService {
                 episode.episodeCode(),
                 episode.releaseDate(),
                 episode.characters().stream()
-                        .map(character -> character.replace("https://rickandmortyapi.com/api/character/",
-                                Config.base_url + "/characters/"))
+                        .map(character -> character.replace(config.getApiBaseUrl() + "/character/",
+                                config.getLocalBaseUrl() + "/characters/"))
                         .collect(Collectors.toList()));
     }
 }

--- a/src/main/java/com/rickmorty/Services/EpisodeService.java
+++ b/src/main/java/com/rickmorty/Services/EpisodeService.java
@@ -82,7 +82,7 @@ public class EpisodeService {
                 .orElse(null);
     
         String prevUrl = Optional.ofNullable(originalInfo.prev())
-                .map(prev -> prev.replace(config.getApiBaseUrl() + "/episodes",
+                .map(prev -> prev.replace(config.getApiBaseUrl() + "/episode",
                         config.getLocalBaseUrl() + "/episodes"))
                 .orElse(null);
     

--- a/src/main/java/com/rickmorty/Services/LocationService.java
+++ b/src/main/java/com/rickmorty/Services/LocationService.java
@@ -8,6 +8,7 @@ import com.rickmorty.DTO.LocationDto;
 import com.rickmorty.Utils.Config;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 
@@ -24,7 +25,8 @@ import java.util.stream.Collectors;
 @Service
 public class LocationService {
 
-    private static final String URL_API = "https://rickandmortyapi.com/api";
+    @Autowired
+    Config config;
 
     private final ObjectMapper objectMapper;
 
@@ -38,7 +40,7 @@ public class LocationService {
             HttpClient client = HttpClient.newHttpClient();
 
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(URL_API + "/location/" + (page != null ? "?page=" +page : "")))
+                    .uri(URI.create(config.getApiBaseUrl() + "/location/" + (page != null ? "?page=" +page : "")))
                     .build();
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 
@@ -56,7 +58,7 @@ public class LocationService {
             HttpClient client = HttpClient.newHttpClient();
 
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(URL_API + "/location/" + id))
+                    .uri(URI.create(config.getApiBaseUrl() + "/location/" + id))
                     .build();
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 
@@ -79,12 +81,12 @@ public class LocationService {
     }
 
 
-    private static InfoDto RewriteInfoDto(InfoDto originalInfo) {
+    private InfoDto RewriteInfoDto(InfoDto originalInfo) {
         return new InfoDto(
                 originalInfo.count(),
                 originalInfo.pages(),
-                originalInfo.next() != null ? originalInfo.next().replace("https://rickandmortyapi.com/api/location/", Config.base_url + "/locations") : null,
-                originalInfo.prev() != null ? originalInfo.prev().replace("https://rickandmortyapi.com/api/location/", Config.base_url + "/locations") : null
+                originalInfo.next() != null ? originalInfo.next().replace(config.getApiBaseUrl() + "/location/", config.getLocalBaseUrl() + "/locations") : null,
+                originalInfo.prev() != null ? originalInfo.prev().replace(config.getApiBaseUrl() + "/location/", config.getLocalBaseUrl() + "/locations") : null
         );
     }
 
@@ -95,10 +97,10 @@ public class LocationService {
                 location.type(),
                 location.dimension(),
                 location.residents().stream()
-                        .map(resident -> resident.replace("https://rickandmortyapi.com/api/character/",
-                                Config.base_url + "/characters/"))
+                        .map(resident -> resident.replace(config.getApiBaseUrl() + "/character/",
+                                config.getLocalBaseUrl() + "/characters/"))
                         .collect(Collectors.toList()),
-                location.url().replace("https://rickandmortyapi.com/api/location/", Config.base_url + "/locations/")
+                location.url().replace("https://rickandmortyapi.com/api/location/", config.getLocalBaseUrl() + "/locations/")
         );
     }
 

--- a/src/main/java/com/rickmorty/Services/LocationService.java
+++ b/src/main/java/com/rickmorty/Services/LocationService.java
@@ -100,7 +100,7 @@ public class LocationService {
                         .map(resident -> resident.replace(config.getApiBaseUrl() + "/character/",
                                 config.getLocalBaseUrl() + "/characters/"))
                         .collect(Collectors.toList()),
-                location.url().replace("https://rickandmortyapi.com/api/location/", config.getLocalBaseUrl() + "/locations/")
+                location.url().replace(config.getApiBaseUrl()+"/location/", config.getLocalBaseUrl() + "/locations/")
         );
     }
 

--- a/src/main/java/com/rickmorty/Utils/Config.java
+++ b/src/main/java/com/rickmorty/Utils/Config.java
@@ -1,5 +1,19 @@
 package com.rickmorty.Utils;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
 public class Config {
-    public static String base_url = "http://localhost:8080";
+    @Value("${api.base.url}")
+    private String apiBaseUrl;
+    @Value("${local.base.url}")
+    private String localBaseUrl;
+
+    public String getApiBaseUrl() {
+        return apiBaseUrl;
+    }
+    public String getLocalBaseUrl() {
+        return localBaseUrl;
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,9 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 springdoc.api-docs.enabled=true
 springdoc.swagger-ui.enabled=true
 ##url: http://localhost:8080/swagger-ui/index.html
+
+# URL base for API local
+local.base.url=http://localhost:8080
+
+# URL base for API Rick and Morty
+api.base.url=https://rickandmortyapi.com/api


### PR DESCRIPTION
***Description:***
Este pull request refatora a maneira como as URLs base são utilizadas em todo o projeto. Agora, todas as chamadas para URLs base foram centralizadas em uma nova classe Config, que injeta dependência nas services.

***O que foi feito:***
        Refactor da classe Config para gerenciar as variáveis apiBaseUrl e localBaseUrl, com os valores declarados no application.properties:

```properties
 # URL base for API local
local.base.url=http://localhost:8080

# URL base for API Rick and Morty
api.base.url=https://rickandmortyapi.com/api

```

```Java
@Component
public class Config {
    @Value("${api.base.url}")
    private String apiBaseUrl;
    @Value("${local.base.url}")
    private String localBaseUrl;
...
}
```

 Substituição de chamadas diretas para URLs base nas services para uso do novo modelo.
 Injeção de dependência da classe Config nas services, garantindo centralização e fácil manutenção das URLs base.
```Java
@Autowired
    Config config;

```
Motivação: Essa mudança segue as melhores práticas de modularidade e configurações centralizadas, facilitando a manutenção e garantindo consistência em futuras alterações.