### PR TITLE
RAM-46

### DIFF
--- a/src/main/java/com/rickmorty/Controllers/EpisodeController.java
+++ b/src/main/java/com/rickmorty/Controllers/EpisodeController.java
@@ -16,9 +16,13 @@ public class EpisodeController {
     private EpisodeService episodeService;
 
     @GetMapping
+
     public ResponseEntity<ApiResponseDto<EpisodeDto>> getAllEpisodes(
-        @RequestParam(required = false) Integer page) {
-        ApiResponseDto<EpisodeDto> episodes = episodeService.findAllEpisodes(page);
+        @RequestParam(required = false) Integer page,
+        @RequestParam(required = false) String name,
+        @RequestParam(required = false) String episode,
+        @RequestParam(required = false) String sort) {
+        ApiResponseDto<EpisodeDto> episodes = episodeService.findAllEpisodes(page, name, episode, sort);
         return ResponseEntity.ok(episodes);
     }
 

--- a/src/main/java/com/rickmorty/Controllers/EpisodeController.java
+++ b/src/main/java/com/rickmorty/Controllers/EpisodeController.java
@@ -3,6 +3,7 @@ package com.rickmorty.Controllers;
 import com.rickmorty.DTO.ApiResponseDto;
 import com.rickmorty.DTO.EpisodeDto;
 import com.rickmorty.Services.EpisodeService;
+import com.rickmorty.enums.SortEpisode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +21,7 @@ public class EpisodeController {
         @RequestParam(required = false) Integer page,
         @RequestParam(required = false) String name,
         @RequestParam(required = false) String episode,
-        @RequestParam(required = false) String sort) {
+        @RequestParam(required = false) SortEpisode sort) {
         ApiResponseDto<EpisodeDto> episodes = episodeService.findAllEpisodes(page, name, episode, sort);
         return ResponseEntity.ok(episodes);
     }

--- a/src/main/java/com/rickmorty/Controllers/EpisodeController.java
+++ b/src/main/java/com/rickmorty/Controllers/EpisodeController.java
@@ -16,7 +16,6 @@ public class EpisodeController {
     private EpisodeService episodeService;
 
     @GetMapping
-
     public ResponseEntity<ApiResponseDto<EpisodeDto>> getAllEpisodes(
         @RequestParam(required = false) Integer page,
         @RequestParam(required = false) String name,

--- a/src/main/java/com/rickmorty/Services/EpisodeService.java
+++ b/src/main/java/com/rickmorty/Services/EpisodeService.java
@@ -6,6 +6,7 @@ import com.rickmorty.DTO.ApiResponseDto;
 import com.rickmorty.DTO.EpisodeDto;
 import com.rickmorty.DTO.InfoDto;
 import com.rickmorty.Utils.Config;
+import com.rickmorty.enums.SortEpisode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -24,7 +25,7 @@ public class EpisodeService {
     @Autowired
     Config config;
 
-    public ApiResponseDto<EpisodeDto> findAllEpisodes(Integer page, String name, String episode, String sort) {
+    public ApiResponseDto<EpisodeDto> findAllEpisodes(Integer page, String name, String episode, SortEpisode sort) {
         try {
             StringBuilder urlBuilder = new StringBuilder(config.getApiBaseUrl() + "/episode?");
             if (page != null) urlBuilder.append("page=").append(page).append("&");
@@ -42,7 +43,7 @@ public class EpisodeService {
             ApiResponseDto<EpisodeDto> apiResponseDto = objectMapper.readValue(response.body(),
                     new TypeReference<ApiResponseDto<EpisodeDto>>() {
                     });
-            return rewriteApiResponse(apiResponseDto, sort);
+            return rewriteApiResponse(apiResponseDto, String.valueOf(sort));
         } catch (Exception e) {
             log.error("Erro ao buscar episódios: " + e.getMessage(), e);
         }
@@ -71,7 +72,7 @@ public class EpisodeService {
 
         List<EpisodeDto> updatedResults = apiResponseDto.results().stream()
                 .map(this::rewriteEpisodeDto)
-                .sorted((e1, e2) -> compareEpisodes(e1, e2, sort)) // Ordena com base no sort, se necessário
+                .sorted((e1, e2) -> compareEpisodes(e1, e2, sort))
                 .collect(Collectors.toList());
 
         return new ApiResponseDto<>(updatedInfo, updatedResults);
@@ -87,10 +88,6 @@ public class EpisodeService {
                 return e1.name().compareToIgnoreCase(e2.name());
             case "name_desc":
                 return e2.name().compareToIgnoreCase(e1.name());
-            case "air_date":
-                return e1.releaseDate().compareTo(e2.releaseDate());
-            case "air_date_desc":
-                return e2.releaseDate().compareTo(e1.releaseDate());
             case "episode_code":
                 return e1.episodeCode().compareTo(e2.episodeCode());
             case "episode_code_desc":

--- a/src/main/java/com/rickmorty/Services/EpisodeService.java
+++ b/src/main/java/com/rickmorty/Services/EpisodeService.java
@@ -8,13 +8,11 @@ import com.rickmorty.DTO.InfoDto;
 import com.rickmorty.Utils.Config;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -30,8 +28,8 @@ public class EpisodeService {
         try {
             StringBuilder urlBuilder = new StringBuilder(config.getApiBaseUrl() + "/episode?");
             if (page != null) urlBuilder.append("page=").append(page).append("&");
-            if (name != null) urlBuilder.append("name=").append(page).append("&");
-            if (episode != null) urlBuilder.append("episode=").append(page).append("&");
+            if (name != null) urlBuilder.append("name=").append(name).append("&");
+            if (episode != null) urlBuilder.append("episode=").append(episode).append("&");
 
             HttpClient client = HttpClient.newHttpClient();
             HttpRequest request = HttpRequest.newBuilder()

--- a/src/main/java/com/rickmorty/enums/SortEpisode.java
+++ b/src/main/java/com/rickmorty/enums/SortEpisode.java
@@ -1,0 +1,8 @@
+package com.rickmorty.enums;
+
+public enum SortEpisode {
+    NAME,
+    NAME_DESC,
+    EPISODE_CODE,
+    EPISODE_CODE_DESC
+}


### PR DESCRIPTION
## Add episode filters, sorting options ##

- Implemented filters for episode queries: `page`, `name`, `episode`.
- Added sorting functionality using the `sort` parameter with options for sorting episodes by name and episode code.
- Introduced a new Enum to manage query parameters for better organization and handling in the API.